### PR TITLE
Create forwarding view that requires auth

### DIFF
--- a/journals/apps/journals/models.py
+++ b/journals/apps/journals/models.py
@@ -22,7 +22,7 @@ from journals.apps.search.backend import LARGE_TEXT_FIELD_SEARCH_PROPS
 
 from jsonfield.fields import JSONField
 
-from urllib.parse import urlsplit, urlunsplit
+from urllib.parse import quote, urlsplit, urlunsplit
 
 from wagtail.wagtailadmin.edit_handlers import FieldPanel, StreamFieldPanel
 from wagtail.wagtailimages.edit_handlers import ImageChooserPanel
@@ -215,8 +215,14 @@ class JournalAboutPage(Page):
         discovery_journal_api_client = self.site.siteconfiguration.discovery_journal_api_client
         journal_data = discovery_journal_api_client.journals(self.journal.uuid).get()
         context['journal_data'] = journal_data
-        context['buy_button_url'] = self.generate_basket_url(journal_data['sku'])
+        context['buy_button_url'] = self.generate_require_auth_basket_url(journal_data['sku'])
         return context
+
+    def generate_require_auth_basket_url(self, sku):
+        basket_url = self.generate_basket_url(sku)
+        encoded_basket_url = quote(basket_url)
+        return "/require_auth?forward={}".format(encoded_basket_url)
+
 
     def generate_basket_url(self, sku):
         ecommerce_base_url = self.site.siteconfiguration.ecommerce_public_url_root

--- a/journals/urls.py
+++ b/journals/urls.py
@@ -40,6 +40,7 @@ urlpatterns = auth_urlpatterns + [
     url(r'^cms/', include(wagtailadmin_urls)),
     url(r'^documents/', include(wagtaildocs_urls)),
     url(r'^search/$', search_views.search, name='search'),
+    url(r'^require_auth/$', core_views.required_auth),
     url(r'', include(wagtail_urls)),
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
 


### PR DESCRIPTION
Creates URL path that allows login prior to forwarding. Copying the function docs here:

Used to require the user to log in through the journals service (thus creating an account in Journal for a new user) before being forwarded to the destination URL. This is necessary for verifying a user has an account in Journals so a purchase can be linked to that account.

When generating a basket URL for a product that includes Journal access, it should be created via the following pattern:

```
encoded_basket_url = urllib.parse.quote("<basket_url>")
display_url = "<journals_domain>/require_auth?forward={}".format(encoded_basket_url)
```