### PR TITLE
Rollback to Python 3.5

### DIFF
--- a/Dockerfile-journals
+++ b/Dockerfile-journals
@@ -1,4 +1,4 @@
-FROM edxops/python:3.6
+FROM edxops/python:3.5
 WORKDIR /edx/app/journals/journals
 ADD requirements.txt /edx/app/journals/journals/
 ADD Makefile /edx/app/journals/journals/

--- a/journals/apps/journals/models.py
+++ b/journals/apps/journals/models.py
@@ -317,7 +317,7 @@ class JournalAboutPage(Page):
             scheme,
             netloc,
             '/basket/add/',
-            f'sku={sku}',
+            'sku={sku}'.format(sku=sku),
             ''
         ))
         return basket_url
@@ -329,9 +329,15 @@ class JournalAboutPage(Page):
                 client.journals(self.journal.uuid).patch(data)
             except HttpNotFoundError as err:
                 # Only a WARN because this will often happen on JournalAboutPage creation.
-                logging.warn(f"JournalAboutPage unable to update {service_name} because UUID doesn't exist: {err.content}")
+                logging.warn("JournalAboutPage unable to update {service_name} because UUID doesn't exist: {error}".format(
+                    service_name=service_name,
+                    error=err.content
+                ))
             except HttpClientError as err:
-                logging.error(f"Error updating {service_name} after JournalAboutPage publish: {err.content}")
+                logging.error("Error updating {service_name} after JournalAboutPage publish: {error}".format(
+                    service_name=service_name,
+                    error=err.content
+                ))
 
         discovery_data = {
             "status": "active" if not deactivate else "inactive",


### PR DESCRIPTION
Ubuntu 16.04 doesn't package Python 3.6 and that's what we're using as
a base OS everwhere.