### PR TITLE
Fix logging regression in docker

### DIFF
--- a/journals/settings/local.py
+++ b/journals/settings/local.py
@@ -52,6 +52,11 @@ SOCIAL_AUTH_REDIRECT_IS_HTTPS = False
 
 ENABLE_AUTO_AUTH = True
 
+# Docker does not support the syslog socket at /dev/log. Rely on the console.
+LOGGING['handlers']['local'] = {
+    'class': 'logging.NullHandler',
+}
+
 #####################################################################
 # Lastly, see if the developer has any local overrides.
 if os.path.isfile(join(dirname(abspath(__file__)), 'private.py')):


### PR DESCRIPTION
The recent changes to the logging settings in #33 broke logging in the docker devstack since
docker doesn't support the syslog socket. Copied code from ecommerce:
https://github.com/edx/ecommerce/blob/master/ecommerce/settings/devstack.py#L11