### PR TITLE
Fix error in journal provisioning

### DIFF
--- a/provision-journal.sql
+++ b/provision-journal.sql
@@ -28,8 +28,7 @@ VALUES (
     'USD',
     'edx',
     'edx',
-    'http://edx.devstack.ecommerce:18130/journal/api/v1',
-    null
+    'http://edx.devstack.ecommerce:18130/journal/api/v1'
 );
 UNLOCK TABLES;
 


### PR DESCRIPTION
- Journal provisioning was failing due to an extra line in
  provision-journal.sql which through a value and row number mismatch
  error