### PR TITLE
WL-1630: added RawHTMLBlock to journal page

### DIFF
--- a/journals/apps/journals/blocks.py
+++ b/journals/apps/journals/blocks.py
@@ -53,6 +53,16 @@ class JournalRichTextBlock(blocks.RichTextBlock):
 
 class JournalRawHTMLBlock(blocks.RawHTMLBlock):
     '''JournalRawHTMLBlock component'''
+    def value_for_form(self, value):
+        """
+        Strips dangerous tags from value
+        """
+        soup = parser(six.text_type(value), 'html.parser')
+        forbidden_tags = soup.find_all(["script", "link", "frame", "iframe"])
+        for tag in forbidden_tags:
+            tag.extract()
+        return str(soup)
+
     def get_searchable_content(self, value):
         return [parser(six.text_type(value), 'html.parser').get_text()]
 

--- a/journals/apps/journals/models.py
+++ b/journals/apps/journals/models.py
@@ -276,8 +276,8 @@ class Video(index.Indexed, models.Model):
 # This has to be below the Video model because XBlockVideoBlock imported below imports the Video model.
 # pylint: disable=wrong-import-position
 from .blocks import (
-    JournalRichTextBlock, JournalImageChooserBlock, PDFBlock, XBlockVideoBlock,
-    PDF_BLOCK_TYPE, VIDEO_BLOCK_TYPE, IMAGE_BLOCK_TYPE, RICH_TEXT_BLOCK_TYPE,
+    JournalRichTextBlock, JournalImageChooserBlock, JournalRawHTMLBlock, PDFBlock, XBlockVideoBlock,
+    PDF_BLOCK_TYPE, VIDEO_BLOCK_TYPE, IMAGE_BLOCK_TYPE, RICH_TEXT_BLOCK_TYPE, RAW_HTML_BLOCK_TYPE,
     STREAM_DATA_DOC_FIELD, STREAM_DATA_TYPE_FIELD)  # noqa
 
 
@@ -435,6 +435,7 @@ class JournalPage(Page):
         (RICH_TEXT_BLOCK_TYPE, JournalRichTextBlock(
             features=['h1', 'h2', 'h3', 'ol', 'ul', 'bold', 'italic', 'link', 'hr', 'document-link', 'image']
         )),
+        (RAW_HTML_BLOCK_TYPE, JournalRawHTMLBlock()),
         (IMAGE_BLOCK_TYPE, JournalImageChooserBlock()),
         (PDF_BLOCK_TYPE, PDFBlock()),
         (VIDEO_BLOCK_TYPE, XBlockVideoBlock()),

--- a/journals/apps/journals/tests/test_blocks.py
+++ b/journals/apps/journals/tests/test_blocks.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+"""
+Tests for custom blocks
+"""
+import ddt
+from django.test import TestCase
+
+from journals.apps.journals.blocks import JournalRawHTMLBlock
+
+
+@ddt.ddt
+class TestJournalRawHTMLBlock(TestCase):
+    """
+    Tests for JournalRawHTMLBlock
+    """
+    def setUp(self):
+        super(TestJournalRawHTMLBlock, self).setUp()
+        self.block = JournalRawHTMLBlock()
+
+    @ddt.data(
+        ('', ''),
+        ('<h1>Heading</h1><p>First Paragraph</p>', '<h1>Heading</h1><p>First Paragraph</p>'),
+        ('<p>First Paragraph</p><script>alert("Test")</script>', '<p>First Paragraph</p>'),
+        (
+                '<p>First Paragraph</p>'
+                '<script>alert("Test")</script>'
+                '<script src="http://example.com" />',
+                '<p>First Paragraph</p>'
+        ),
+        (
+                '<p>First Paragraph</p>'
+                '<script>alert("Test")</script>'
+                '<frame src="http://example.com" />',
+                '<p>First Paragraph</p>'
+        ),
+        ('<p>First Paragraph</p><iframe src="http://example.com" />', '<p>First Paragraph</p>'),
+        ('<p>First Paragraph</p><link rel="stylesheet" type="text/css" href="test.css" />', '<p>First Paragraph</p>'),
+    )
+    @ddt.unpack
+    def test_value_for_form(self, given_value, transformed_value):
+        """
+        Test value of this block is properly cleaned before being saved
+        """
+        self.assertEqual(self.block.value_for_form(given_value), transformed_value)

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -2,6 +2,7 @@
 -r base.txt
 
 bok-choy==0.7.3
+ddt==1.1.3
 django-dynamic-fixture==2.0.0
 django-nose==1.4.5
 edx-lint==0.5.5


### PR DESCRIPTION
This PR has changes to provide content authors ability to add `RawHTMLBlock` to journal page. It modifies `JournalRawHTMLBlock` to strip `script`, `frame`, `iframe` and `link` tags from input.
@bill-filler could you please review?