### PR TITLE
Integrate with New Ecommerce API Path

### DIFF
--- a/provision-journal.sql
+++ b/provision-journal.sql
@@ -28,7 +28,7 @@ VALUES (
     'USD',
     'edx',
     'edx',
-    'http://edx.devstack.ecommerce:18130/journal/api/v1',
+    'http://edx.devstack.ecommerce:18130/journals/api/v1',
     'http://localhost:1991'
 );
 UNLOCK TABLES;


### PR DESCRIPTION
The journal ecommerce api was changed from 'journal/api/v1' to
'journals/api/v1'.  This change is to accomadate that change.

Note: This change is dependent on:
  https://github.com/edx/ecommerce/pull/1790