### PR TITLE
WL-1563: changes to make document and images collection selection site specific

### DIFF
--- a/journals/apps/core/wagtail_hooks.py
+++ b/journals/apps/core/wagtail_hooks.py
@@ -4,7 +4,9 @@ Wagtail hooks to customize wagtail operations for journals
 from wagtail.wagtailadmin.site_summary import PagesSummaryItem
 from wagtail.wagtailcore import hooks
 from wagtail.wagtaildocs.wagtail_hooks import DocumentsSummaryItem
+from wagtail.wagtaildocs.permissions import permission_policy as document_permission_policy
 from wagtail.wagtailimages.wagtail_hooks import ImagesSummaryItem
+from wagtail.wagtailimages.permissions import permission_policy as image_permission_policy
 
 from journals.apps.journals.models import WagtailModelManager
 
@@ -65,3 +67,25 @@ def add_pages_summary_item(request, items):
     items.append(JournalsPagesSummaryItem(request))
     items.append(JournalsImagesSummaryItem(request))
     items.append(JournalsDocumentsSummaryItem(request))
+
+
+@hooks.register('construct_document_chooser_queryset')
+def documents_with_add_or_change_permissions_only(documents, request):  # pylint: disable=unused-argument
+    """
+    Show documents from those collections where user has add or change permissions
+    """
+
+    return document_permission_policy.instances_user_has_any_permission_for(
+        request.user, ['add', 'change']
+    )
+
+
+@hooks.register('construct_image_chooser_queryset')
+def images_with_add_or_change_permissions_only(images, request):  # pylint: disable=unused-argument
+    """
+    Show images from those collections where user has add or change permissions
+    """
+
+    return image_permission_policy.instances_user_has_any_permission_for(
+        request.user, ['add', 'change']
+    )

--- a/journals/apps/journals/templates/wagtailadmin/shared/collection_chooser.html
+++ b/journals/apps/journals/templates/wagtailadmin/shared/collection_chooser.html
@@ -1,0 +1,20 @@
+{% load i18n %}
+{% load l10n %}
+{% load wagtail_tags %}
+
+<li>
+    <div class="field choice_field select">
+        <label for="collection_chooser_collection_id">{% trans "Collection" %}:</label>
+        <div class="field-content">
+            <div class="input">
+                <select id="collection_chooser_collection_id" name="collection_id">
+                    <option value="">{% trans "All collections" %}</option>
+                    {% for collection in collections|with_permissions:request %}
+                        <option value="{{ collection.id|unlocalize }}" {% if collection == current_collection %}selected="selected"{% endif %}>{{ collection.name }}</option>
+                    {% endfor %}
+                </select>
+                <span></span>
+            </div>
+        </div>
+    </div>
+</li>

--- a/journals/apps/journals/templatetags/wagtail_tags.py
+++ b/journals/apps/journals/templatetags/wagtail_tags.py
@@ -1,0 +1,22 @@
+"""
+This module has those template tags/filters which we use in Wagtail template overrides.
+"""
+from django import template
+
+from journals.apps.journals.models import WagtailModelManager
+
+
+register = template.Library()
+
+
+@register.filter(name='with_permissions')
+def collections_user_has_access(collections, request):
+    """
+    Args:
+        collections: queryset of collection objects
+        request: http request object
+
+    Returns: queryset of collection objects striping those where user does not have add or change permissions
+
+    """
+    return WagtailModelManager.get_user_collections(request.user, collections)

--- a/journals/settings/base.py
+++ b/journals/settings/base.py
@@ -32,21 +32,8 @@ INSTALLED_APPS = (
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
-    'wagtail.wagtailforms',
-    'wagtail.wagtailredirects',
-    'wagtail.wagtailembeds',
-    'wagtail.wagtailsites',
-    'wagtail.wagtailusers',
-    'wagtail.wagtailsnippets',
-    'wagtail.wagtaildocs',
-    'wagtail.wagtailimages',
-    'wagtail.wagtailsearch',
-    'wagtail.wagtailadmin',
-    'wagtail.wagtailcore',
-    'wagtail.contrib.settings',
     'modelcluster',
     'taggit',
-
 )
 
 THIRD_PARTY_APPS = (
@@ -64,8 +51,24 @@ PROJECT_APPS = (
     'journals.apps.theming'
 )
 
+WAGTAIL_APPS = (
+    'wagtail.wagtailforms',
+    'wagtail.wagtailredirects',
+    'wagtail.wagtailembeds',
+    'wagtail.wagtailsites',
+    'wagtail.wagtailusers',
+    'wagtail.wagtailsnippets',
+    'wagtail.wagtaildocs',
+    'wagtail.wagtailimages',
+    'wagtail.wagtailsearch',
+    'wagtail.wagtailadmin',
+    'wagtail.wagtailcore',
+    'wagtail.contrib.settings',
+)
+
 INSTALLED_APPS += THIRD_PARTY_APPS
 INSTALLED_APPS += PROJECT_APPS
+INSTALLED_APPS += WAGTAIL_APPS
 
 MIDDLEWARE_CLASSES = (
     'django.contrib.sessions.middleware.SessionMiddleware',


### PR DESCRIPTION
This PR has changes to restrict image and document chooser dialogs show only those images/documents which belongs to a collection where user has `add` or `change` permissions in wagtail admin. It has changes to display only those collections in `Collections` drop-downs inside document/image chooser dialogs where user has `add` or `change` permissions.
@bill-filler could you please review?