### PR TITLE
sending JournalsAboutPage title instead of Journal name to the other services

### DIFF
--- a/journals/apps/journals/management/commands/publish_journals.py
+++ b/journals/apps/journals/management/commands/publish_journals.py
@@ -44,7 +44,6 @@ class Command(BaseCommand):
         try:
             journal = Journal.objects.create_journal(name, org, access_length)
             journal_about_page = self._update_wagtail_pages(journal, create=True, publish=publish)
-            journal.refresh_from_db()  # since we are updating journal object in signals.
 
             journal_meta_data = JournalMetaData(
                 journal_about_page,
@@ -107,7 +106,7 @@ class Command(BaseCommand):
                 journal_about_page.specific.save()
         else:
             journal_about_page = JournalAboutPage(
-                title='{} About Page'.format(journal.name),
+                title=journal.name,
                 journal=journal,
                 short_description='{} description'.format(journal.name),
                 long_description=''

--- a/journals/apps/journals/management/commands/publish_journals.py
+++ b/journals/apps/journals/management/commands/publish_journals.py
@@ -44,6 +44,7 @@ class Command(BaseCommand):
         try:
             journal = Journal.objects.create_journal(name, org, access_length)
             journal_about_page = self._update_wagtail_pages(journal, create=True, publish=publish)
+            journal.refresh_from_db()  # since we are updating journal object in signals.
 
             journal_meta_data = JournalMetaData(
                 journal_about_page,

--- a/journals/apps/journals/models.py
+++ b/journals/apps/journals/models.py
@@ -370,6 +370,10 @@ class JournalAboutPage(Page):
             "slug": self.slug
         }
 
+        if self.journal:
+            self.journal.name = self.title
+            self.journal.save()
+
         update_service(
             self.site.siteconfiguration.discovery_journal_api_client,
             discovery_data,

--- a/journals/apps/journals/models.py
+++ b/journals/apps/journals/models.py
@@ -118,7 +118,7 @@ class JournalMetaData(object):
             'uuid': str(self.journal.uuid),
             'partner': self.journal.organization.site.siteconfiguration.discovery_partner_id,
             'organization': self.journal.organization.name,
-            'title': self.journal_about_page.title,
+            'title': self.journal.name,
             'price': self.price,
             'currency': self.currency,
             'sku': self.sku,
@@ -135,7 +135,7 @@ class JournalMetaData(object):
         return {
             'structure': 'standalone',
             'product_class': 'Journal',
-            'title': self.journal_about_page.title,
+            'title': self.journal.name,
             'expires': self.expires,
             'attribute_values': [
                 {


### PR DESCRIPTION
journals management command `publish_journals` was sending `Journal`'s name to **e-commerce** and **discovery** services. but we were expecting to send `JournalsAboutPage`'s title to **discovery** and **e-commerce** like we do on Edit `JournalAboutPage`.