### PR TITLE
Create AboutPage API with Journal Structure Field

### DIFF
--- a/journals/apps/api/v1/content/urls.py
+++ b/journals/apps/api/v1/content/urls.py
@@ -1,0 +1,9 @@
+"""
+Wagtail APIs
+"""
+from wagtail.api.v2.endpoints import PagesAPIEndpoint
+from wagtail.api.v2.router import WagtailAPIRouter
+
+wagtail_router = WagtailAPIRouter('wagtailapi')
+
+wagtail_router.register_endpoint('pages', PagesAPIEndpoint)

--- a/journals/apps/journals/journal_page_helper.py
+++ b/journals/apps/journals/journal_page_helper.py
@@ -1,0 +1,22 @@
+""" Helpers for Journal Page Types """
+
+
+class JournalPageMixin(object):
+    """ This class contains methods that are shared between Journal Page Types """
+
+    def get_nested_children(self):
+        """ Return dict hierarchy with self as root """
+
+        # TODO: can remove "url" field once we move to seperated front end
+        structure = {
+            "title": self.title,
+            "children": None,
+            "id": self.id,
+            "url": self.url
+        }
+        children = self.get_children()
+        if not children:
+            return structure
+
+        structure["children"] = [child.specific.get_nested_children() for child in children]
+        return structure

--- a/journals/settings/base.py
+++ b/journals/settings/base.py
@@ -52,6 +52,7 @@ PROJECT_APPS = (
 )
 
 WAGTAIL_APPS = (
+    'wagtail.api.v2',
     'wagtail.wagtailforms',
     'wagtail.wagtailredirects',
     'wagtail.wagtailembeds',

--- a/journals/urls.py
+++ b/journals/urls.py
@@ -21,9 +21,10 @@ from django.conf.urls import include, url
 from django.conf.urls.static import static
 from django.contrib import admin
 from wagtail.wagtailadmin import urls as wagtailadmin_urls
-from wagtail.wagtaildocs import urls as wagtaildocs_urls
 from wagtail.wagtailcore import urls as wagtail_urls
+from wagtail.wagtaildocs import urls as wagtaildocs_urls
 
+from journals.apps.api.v1.content.urls import wagtail_router
 from journals.apps.core import views as core_views
 from journals.apps.search import views as search_views
 
@@ -32,6 +33,7 @@ admin.autodiscover()
 urlpatterns = auth_urlpatterns + [
     url(r'^admin/', include(admin.site.urls)),
     url(r'^api/', include('journals.apps.api.urls', namespace='api')),
+    url(r'^api/v1/content/', include(wagtail_router.urls)),
     # Use the same auth views for all logins, including those originating from the browseable API.
     url(r'^api-auth/', include(auth_urlpatterns, namespace='rest_framework')),
     url(r'^auto_auth/$', core_views.AutoAuth.as_view(), name='auto_auth'),


### PR DESCRIPTION
- Enabled the wagtail 'pages' api which lets you query journal pages
- Added a custom field to AboutPage to get the hierarchical structure of
  the journal

Usage (on local devstack):
- To get a json blob of all pages in the Journals service go to:
  http://localhost:18606/api/v1/content/pages/
  - There are a variety of filtering and ordering options. For more
    information see the wagtail documentation:
    http://docs.wagtail.io/en/v1.7/advanced_topics/api/v2/usage.html
- To get the hierarchical structure of a journal go to:
  http://localhost:18606/api/v1/content/pages/?slug=JOURNAL-ABOUT-PAGE-SLUG&type=journals.JournalAboutPage&fields=get_journal_structure

Remaining Work:
- Testing for this API endpoint