### PR TITLE
Create Site Branding API

### DIFF
--- a/journals/apps/api/v1/theming/filters.py
+++ b/journals/apps/api/v1/theming/filters.py
@@ -1,0 +1,18 @@
+""" Filter class for theming / site branding """
+from django_filters import rest_framework as filters
+
+from journals.apps.theming.models import SiteBranding
+
+
+class SiteBrandingFilter(filters.FilterSet):
+    """ Filter for SiteBranding """
+    site_name = filters.CharFilter(name='site__site_name')
+    hostname = filters.CharFilter(name='site__hostname')
+
+    class Meta:
+        model = SiteBranding
+        fields = [
+            'theme_name',
+            'site_name',
+            'hostname',
+        ]

--- a/journals/apps/api/v1/theming/serializers.py
+++ b/journals/apps/api/v1/theming/serializers.py
@@ -1,0 +1,49 @@
+""" Theming / Site Branding Serializers"""
+from rest_framework import serializers
+from wagtail.wagtailcore.models import Site
+from wagtail.wagtailimages.models import Image
+
+from journals.apps.theming.models import SiteBranding
+
+
+class SiteSerializer(serializers.ModelSerializer):
+    """
+    Serializer for the site associated with a site brand
+    """
+
+    class Meta(object):
+        model = Site
+        fields = (
+            'site_name',
+            'hostname',
+        )
+
+
+class SiteLogoSerializer(serializers.ModelSerializer):
+    """
+    Serializer for the site logo associated with a site brand
+    """
+
+    class Meta(object):
+        model = Image
+        fields = (
+            'title',
+            'file',
+        )
+
+
+class SiteBrandingSerializer(serializers.ModelSerializer):
+    """
+    Serializer for the ```SiteBranding``` model.
+    """
+    site_logo = SiteLogoSerializer(many=False, read_only=True)
+    site = SiteSerializer(many=False, read_only=True)
+
+    class Meta(object):
+        model = SiteBranding
+        read_only = True
+        fields = (
+            'theme_name',
+            'site_logo',
+            'site'
+        )

--- a/journals/apps/api/v1/theming/views.py
+++ b/journals/apps/api/v1/theming/views.py
@@ -1,0 +1,15 @@
+""" API for theming / site branding """
+from django_filters.rest_framework import DjangoFilterBackend
+from rest_framework import viewsets
+
+from journals.apps.api.v1.theming.filters import SiteBrandingFilter
+from journals.apps.api.v1.theming.serializers import SiteBrandingSerializer
+from journals.apps.theming.models import SiteBranding
+
+
+class SiteBrandingViewSet(viewsets.ReadOnlyModelViewSet):
+    """ API for SiteBranding model """
+    serializer_class = SiteBrandingSerializer
+    queryset = SiteBranding.objects.all()
+    filter_backends = (DjangoFilterBackend, )
+    filter_class = SiteBrandingFilter

--- a/journals/apps/api/v1/urls.py
+++ b/journals/apps/api/v1/urls.py
@@ -1,8 +1,10 @@
 """ API v1 URLs. """
 from rest_framework.routers import DefaultRouter
 
+from journals.apps.api.v1.theming.views import SiteBrandingViewSet
 from .views import JournalAccessViewSet
 
 router = DefaultRouter()
 router.register(r'journalaccess', JournalAccessViewSet, base_name='journalaccess')
+router.register(r'sitebranding', SiteBrandingViewSet, base_name='sitebranding')
 urlpatterns = router.urls


### PR DESCRIPTION
- Create Endpoint to access Site Branding information

Usage:
- Path to API Endpoint: /api/v1/sitebranding/
- Query Params:
  - theme_name: Name of site branding theme
  - site_name: Name of associated site
  - hostname: Hostname for assocated site

Remaining Work:
- Tests