### PR TITLE
Allow CORS requests to APIs

### DIFF
--- a/journals/settings/base.py
+++ b/journals/settings/base.py
@@ -41,6 +41,7 @@ THIRD_PARTY_APPS = (
     'social_django',
     'waffle',
     'django_filters',
+    'corsheaders',
 )
 
 PROJECT_APPS = (
@@ -73,6 +74,7 @@ INSTALLED_APPS += WAGTAIL_APPS
 
 MIDDLEWARE_CLASSES = (
     'django.contrib.sessions.middleware.SessionMiddleware',
+    'corsheaders.middleware.CorsMiddleware',
     'django.middleware.locale.LocaleMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
@@ -324,3 +326,5 @@ WAGTAILDOCS_DOCUMENT_MODEL = 'journals.JournalDocument'
 WAGTAIL_FRONTEND_LOGIN_URL = LOGIN_URL
 
 THEME_DIR = '/edx/app/journals/themes/'
+
+CORS_ALLOW_CREDENTIALS = True

--- a/journals/settings/local.py
+++ b/journals/settings/local.py
@@ -57,6 +57,10 @@ LOGGING['handlers']['local'] = {
     'class': 'logging.NullHandler',
 }
 
+CORS_ORIGIN_WHITELIST = (
+    'localhost:1991'
+)
+
 #####################################################################
 # Lastly, see if the developer has any local overrides.
 if os.path.isfile(join(dirname(abspath(__file__)), 'private.py')):

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -14,3 +14,4 @@ jsonfield==2.0.2
 mysqlclient==1.3.12
 pytz==2018.3
 wagtail>=1.13,<1.14
+django-cors-headers==2.3.0


### PR DESCRIPTION
Add CORS library to handle cross domain requests to service. Also adds
the port from our development server to the local whitelist.