### PR TITLE
Add authorization checking on Wagtail Pages API

### DIFF
--- a/journals/apps/api/v1/content/tests/test_content_api.py
+++ b/journals/apps/api/v1/content/tests/test_content_api.py
@@ -1,13 +1,23 @@
 """ Test Cases for /api/v1/content/ APIs """
+import datetime
 import json
 
 from django.test import TestCase
 from django.urls import reverse
 
-from journals.apps.core.tests.factories import UserFactory, USER_PASSWORD
-from journals.apps.core.tests.utils import (TEST_JOURNAL_STRUCTURE,
-                                            create_journal_about_page_factory,
-                                            is_nested_json_equivalent)
+from journals.apps.core.tests.factories import (
+    JournalFactory,
+    JournalAccessFactory,
+    OrganizationFactory,
+    SiteFactory,
+    UserFactory,
+    USER_PASSWORD
+)
+from journals.apps.core.tests.utils import (
+    TEST_JOURNAL_STRUCTURE,
+    create_journal_about_page_factory,
+    is_nested_json_equivalent
+)
 
 
 class TestContentPagesAPI(TestCase):
@@ -18,7 +28,18 @@ class TestContentPagesAPI(TestCase):
 
         self.user = UserFactory()
         self.test_about_page_slug = 'journal-about-page-slug'
+        self.site = SiteFactory()
+        self.org = OrganizationFactory(site=self.site)
+        self.journal = JournalFactory(
+            organization=self.org
+        )
+        self.journal_access = JournalAccessFactory(
+            journal=self.journal,
+            user=self.user,
+            expiration_date=datetime.date.today() + datetime.timedelta(days=1)
+        )
         self.journal_about_page = create_journal_about_page_factory(
+            journal=self.journal,
             journal_structure=self.journal_test_data,
             about_page_slug=self.test_about_page_slug
         )

--- a/journals/apps/api/v1/content/urls.py
+++ b/journals/apps/api/v1/content/urls.py
@@ -1,9 +1,10 @@
 """
 Wagtail APIs
 """
-from wagtail.api.v2.endpoints import PagesAPIEndpoint
 from wagtail.api.v2.router import WagtailAPIRouter
+
+from journals.apps.api.v1.content.views import JournalPagesAPIEndpoint
 
 wagtail_router = WagtailAPIRouter('content')
 
-wagtail_router.register_endpoint('pages', PagesAPIEndpoint)
+wagtail_router.register_endpoint('pages', JournalPagesAPIEndpoint)

--- a/journals/apps/api/v1/content/views.py
+++ b/journals/apps/api/v1/content/views.py
@@ -1,0 +1,19 @@
+"""
+Overridden Wagtail API endpoints
+"""
+from rest_framework.permissions import AllowAny
+from wagtail.api.v2.endpoints import PagesAPIEndpoint
+
+from journals.apps.api.filters import PageAuthorizationFilter
+
+
+class JournalPagesAPIEndpoint(PagesAPIEndpoint):
+    """
+    Filters out some page types if the requesting user doesn't have access to them.
+
+    We need to return JournalIndexPage and JournalAboutPage content types to everyone (including anonymous).
+    We also need to check a user's access to a Journal before returning any JournalPage attached to that journal.
+    """
+
+    permission_classes = (AllowAny, )
+    filter_backends = [PageAuthorizationFilter] + PagesAPIEndpoint.filter_backends

--- a/journals/apps/core/tests/factories.py
+++ b/journals/apps/core/tests/factories.py
@@ -2,6 +2,7 @@
 
 import random
 import string
+import uuid
 
 from urllib.parse import urljoin, urlsplit, urlunsplit
 
@@ -11,7 +12,7 @@ from faker import Faker
 from wagtail.wagtailcore.models import Page, Site
 from wagtail.wagtailimages.models import Image
 
-from journals.apps.journals.models import JournalAboutPage, JournalPage
+from journals.apps.journals.models import JournalAboutPage, JournalPage, Journal, JournalAccess, Organization
 from journals.apps.core.models import SiteConfiguration, User
 from journals.apps.theming.models import SiteBranding
 
@@ -89,6 +90,32 @@ class PageFactory(factory.DjangoModelFactory):
 
     class Meta:
         model = Page
+
+
+class OrganizationFactory(factory.DjangoModelFactory):
+    """ Model factory for Organization model """
+    name = FuzzyText(prefix='org-name')
+
+    class Meta:
+        model = Organization
+
+
+class JournalFactory(factory.DjangoModelFactory):
+    """ Model factory for Journal model """
+    uuid = uuid.uuid4()
+    name = FuzzyText(prefix='journal-name')
+
+    class Meta:
+        model = Journal
+
+
+class JournalAccessFactory(factory.DjangoModelFactory):
+    """ Model factory for JournalAccess model """
+    uuid = uuid.uuid4()
+    revoked = False
+
+    class Meta:
+        model = JournalAccess
 
 
 class JournalAboutPageFactory(factory.DjangoModelFactory):

--- a/journals/apps/core/tests/utils.py
+++ b/journals/apps/core/tests/utils.py
@@ -71,7 +71,7 @@ def child_path_gen(parent_path):
         yield parent_path + child_path_suffix
 
 
-def create_journal_about_page_factory(journal_structure, about_page_slug=None):
+def create_journal_about_page_factory(journal, journal_structure, about_page_slug=None):
     """
     Creates JournalAboutPageFactory and all of its sub pages that are defined in the journal_structure
 
@@ -92,6 +92,7 @@ def create_journal_about_page_factory(journal_structure, about_page_slug=None):
     children = journal_structure['structure']
     numchild = len(children)
     about_page_factory = JournalAboutPageFactory(
+        journal=journal,
         title=title,
         path=path,
         numchild=numchild,
@@ -105,13 +106,14 @@ def create_journal_about_page_factory(journal_structure, about_page_slug=None):
             journal_page=child,
             path=next(child_path),
             depth=depth + 1,
-            slug=child['title']
+            slug=child['title'],
+            journal_about_page=about_page_factory
         )
 
     return about_page_factory
 
 
-def create_nested_journal_pages(journal_page, path, depth, slug):
+def create_nested_journal_pages(journal_page, path, depth, slug, journal_about_page):
     """
     Creates a JournalPageFactory and all its sub pages that are defined in the journal_page
 
@@ -137,7 +139,8 @@ def create_nested_journal_pages(journal_page, path, depth, slug):
         path=path,
         numchild=numchild,
         depth=depth,
-        slug=slug
+        slug=slug,
+        journal_about_page=journal_about_page,
     )
 
     child_path = child_path_gen(path)
@@ -146,7 +149,8 @@ def create_nested_journal_pages(journal_page, path, depth, slug):
             journal_page=child,
             path=next(child_path),
             depth=depth + 1,
-            slug=child['title']
+            slug=child['title'],
+            journal_about_page=journal_about_page,
         )
 
 


### PR DESCRIPTION
API now removes all Journal Pages that is attached to a Journal that the user doesn't have access to.