### PR TITLE
Change navigation to only include live (published) pages

### DIFF
--- a/journals/apps/api/v1/preview/views.py
+++ b/journals/apps/api/v1/preview/views.py
@@ -15,7 +15,7 @@ class PreviewView(APIView):
     """
     permission_classes = (WagtailAdminPermission, )
 
-    def get(self, request, cache_key):  # pylint: disable=unused-argument
+    def get(self, request, cache_key):
         """
         Get requested Page object from cache
         """

--- a/journals/apps/journals/journal_page_helper.py
+++ b/journals/apps/journals/journal_page_helper.py
@@ -15,21 +15,61 @@ FRONTEND_PREVIEW_PATH = 'preview'
 class JournalPageMixin(object):
     """ This class contains methods that are shared between Journal Page Types """
 
-    def get_nested_children(self):
+    def flatten_children(self, children):
+        """
+        Children should always be a list of dicts. In the case that a there is an unpublished page between two
+        published pages, the unpublished page will simply be a list of it's children, instead of a dict of it's
+        content, plus a children field. This flattens that list of children into the parent list children to keep
+        a valid tree structure.
+        """
+        flat_children = []
+        for child in children:
+            if isinstance(child, dict):
+                flat_children.append(child)
+            elif isinstance(child, list):
+                for subchild in child:
+                    flat_children.append(subchild)
+        return flat_children
+
+    def get_nested_children(self, live_only=True):
         """ Return dict hierarchy with self as root """
 
         # TODO: can remove "url" field once we move to seperated front end
-        structure = {
-            "title": self.title,
-            "children": None,
-            "id": self.id,
-            "url": self.url
-        }
+        if self.live:
+            structure = {
+                "title": self.title,
+                "children": None,
+                "id": self.id,
+                "url": self.url
+            }
+        else:
+            structure = None
+
         children = self.get_children()
-        if not children:
+        if not children or (live_only and self.get_descendants().live().count() == 0):
             return structure
 
-        structure["children"] = [child.specific.get_nested_children() for child in children]
+        if structure:
+            structure_children = [
+                struct for struct in
+                (
+                    child.specific.get_nested_children(live_only=live_only)
+                    for child in children
+                )
+                if struct is not None
+            ]
+            structure["children"] = self.flatten_children(structure_children)
+        else:
+            structure = [
+                struct for struct in
+                (
+                    child.specific.get_nested_children(live_only=live_only)
+                    for child in children
+                )
+                if struct is not None
+            ]
+            structure = self.flatten_children(structure)
+
         return structure
 
     def get_serializer(self, request):


### PR DESCRIPTION
Currently our page structure and next/prev logic does not take into account whether pages are live or not and it should.

This PR has the changes to conditionally return only the published pages in the appropriate calls.

NOTE:
In testing, there was an added complexity that I didn't realize. You can have published pages beneath a parent that is not published, which makes things rather tricky. For example in this scenario all pages are published except Chapter 2:

```
Chapter 1:
  Page 1-1
Chapter 2: (unpublished)
  Page 2-1
  Page 2-2
Chapter 3:
  Page 3
```
In the TOC view, we'd want this to display as:
```
Chapter 1:
  Page 1-1
Page 2-1
Page 2-2
Chapter 3:
   Page 3
```
Since Chapter 2 is not published we want it's children to display at the same level as the other chapters.
I struggled to get this working correctly in the models.structure() and journal_page_helper.get_nested_children() method. For the above example, structure() now returns this based on the changes I made:
```
[{'children': [{'children': None,
                'id': 34,
                'title': 'Page1-1',
                'url': '/demo-journal/chapter-1/page1-1/'}],
  'id': 33,
  'title': 'Chapter 1',
  'url': '/demo-journal/chapter-1/'},
 [{'children': None,
   'id': 36,
   'title': 'Page2-1',
   'url': '/demo-journal/chapter2/page2-1/'},
  {'children': None,
   'id': 37,
   'title': 'Page2-2',
   'url': '/demo-journal/chapter2/page2-2/'}],
 {'children': [{'children': None,
                'id': 39,
                'title': 'Page3-1',
                'url': '/demo-journal/chapter3/page3-1/'}],
  'id': 38,
  'title': 'Chapter3',
  'url': '/demo-journal/chapter3/'}]
```

Note that Page2-1 and Page2-2 are in a list and this breaks the current TOC rendered by backend. Ideally we'd want them to be top level structs just like Chapter1 but I couldn't figure this out. Need HELP!!
This is how it should be:
```
[{'children': [{'children': None,
                'id': 34,
                'title': 'Page1-1',
                'url': '/demo-journal/chapter-1/page1-1/'}],
  'id': 33,
  'title': 'Chapter 1',
  'url': '/demo-journal/chapter-1/'},
 {'children': None,
   'id': 36,
   'title': 'Page2-1',
   'url': '/demo-journal/chapter2/page2-1/'},
  {'children': None,
   'id': 37,
   'title': 'Page2-2',
   'url': '/demo-journal/chapter2/page2-2/'},
 {'children': [{'children': None,
                'id': 39,
                'title': 'Page3-1',
                'url': '/demo-journal/chapter3/page3-1/'}],
  'id': 38,
  'title': 'Chapter3',
  'url': '/demo-journal/chapter3/'}]
```


