### PR TITLE
don't save page when previewing

### DIFF
--- a/journals/apps/journals/models.py
+++ b/journals/apps/journals/models.py
@@ -805,7 +805,11 @@ class JournalPage(JournalPageMixin, Page):
         """ Gets the journal about page field and calculates it if null """
         if not self.journal_about_page:
             self.journal_about_page = self._calculate_journal_about_page()
-            self.save()
+            # only save if page has been published otherwise saving causes
+            # page to be published which causes a problem for preview use-case
+            if self.page_ptr_id:
+                self.save()
+
         return self.journal_about_page
 
     def _calculate_journal_about_page(self):


### PR DESCRIPTION
previews were broken because we were saving the journal page during the call to get_journals() from serve() method. Seems the only reliable way to check if page is live is to make sure page_ptr_id is not None. The .live property always returns true which is not what I expected