### PR TITLE
WL-1780: Moved creation video and document index into celery tasks

### DIFF
--- a/journals/__init__.py
+++ b/journals/__init__.py
@@ -1,0 +1,7 @@
+"""
+Journals module initialization
+Loading celery app so that task registration and discovery can work correctly.
+"""
+from .celery import app as celery_app
+
+__all__ = ('celery_app',)

--- a/journals/apps/search/tasks.py
+++ b/journals/apps/search/tasks.py
@@ -1,0 +1,57 @@
+"""
+Module to define celery tasks for search related features
+"""
+import logging
+
+from celery.task import task
+from wagtail.wagtailsearch.backends import get_search_backends
+
+log = logging.getLogger(__name__)
+
+
+@task(bind=True, default_retry_delay=10, max_retries=2)
+def task_index_journal_document(self, document_id):  # pylint: disable=unused-argument
+    """
+    Celery task to create elastic search index for journal documents
+    """
+    from journals.apps.journals.models import JournalDocument
+    from journals.apps.search.backend import INGEST_ATTACHMENT_ID
+
+    try:
+        item = JournalDocument.objects.get(pk=document_id)
+    except JournalDocument.DoesNotExist:
+        log.error('JournalDocument with id %s does not exist', document_id)
+        return
+
+    for backend in get_search_backends():
+        search_index = backend.get_index_for_model(type(item))
+    mapping = search_index.mapping_class(item.__class__)
+    results = search_index.es.index(
+        search_index.name,
+        mapping.get_document_type(),
+        mapping.get_document(item),
+        pipeline=INGEST_ATTACHMENT_ID,
+        id=mapping.get_document_id(item)
+    )
+    log.info('indexed document with attachment results=%s', results)
+
+
+@task(bind=True, default_retry_delay=10, max_retries=2)
+def task_index_journal_video(self, video_id):  # pylint: disable=unused-argument
+    """
+    Celery task to create elastic search index for videos
+    """
+    from journals.apps.journals.models import Video
+
+    try:
+        item = Video.objects.get(pk=video_id)
+    except Video.DoesNotExist:
+        log.error('Video with id %s does not exist', video_id)
+        return
+
+    for backend in get_search_backends():
+        search_index = backend.get_index_for_model(type(item))
+
+    # call add_item method of base class to avoid recursive loop
+    super(search_index.__class__, search_index).add_item(item)
+    log.info('indexed video with id=%s', video_id)

--- a/journals/celery.py
+++ b/journals/celery.py
@@ -1,0 +1,20 @@
+"""
+Celery setup file
+"""
+from __future__ import absolute_import, unicode_literals
+
+import os
+from celery import Celery
+
+# set the default Django settings module for the 'celery' program.
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'journals.settings.local')
+app = Celery('journals')
+
+# Using a string here means the worker doesn't have to serialize
+# the configuration object to child processes.
+# - namespace='CELERY' means all celery-related configuration keys
+#   should have a `CELERY_` prefix.
+app.config_from_object('django.conf:settings', namespace='CELERY')
+
+# Load task modules from all registered Django app configs.
+app.autodiscover_tasks()

--- a/journals/settings/local.py
+++ b/journals/settings/local.py
@@ -61,6 +61,9 @@ CORS_ORIGIN_WHITELIST = (
     'localhost:1991'
 )
 
+# CELERY SETTINGS
+CELERY_BROKER_URL = 'replace-me'
+
 #####################################################################
 # Lastly, see if the developer has any local overrides.
 if os.path.isfile(join(dirname(abspath(__file__)), 'private.py')):

--- a/journals/settings/test.py
+++ b/journals/settings/test.py
@@ -47,6 +47,8 @@ DATABASES = {
 }
 # END TEST DATABASE
 
+CELERY_TASK_ALWAYS_EAGER = True
+
 # Docker does not support the syslog socket at /dev/log. Rely on the console.
 LOGGING['handlers']['local'] = {
     'class': 'logging.NullHandler',

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,4 +1,5 @@
 beautifulsoup4>=4.6.0,<5.0.0
+celery==4.2.1
 django==1.11.15
 django-filter==1.1.0
 django-extensions==2.0.0
@@ -16,5 +17,6 @@ elasticsearch>=5.0.0,<6.0.0
 jsonfield==2.0.2
 mysqlclient==1.3.12
 pytz==2018.3
+redis==2.10.6
 wagtail>=1.13,<1.14
 django-cors-headers==2.3.0


### PR DESCRIPTION
This PR has changes to setup celery as background task worker in journals and creations of video and document index via celery background tasks at the time of video import or document upload to avoid getting request time out or gateway time out errors.
Changes are tested with `redis` as celery's broker transport using [redistogo](https://redistogo.com/) free instance by setting ``
`CELERY_BROKER_URL = 'redis://redistogo:***@barreleye.redistogo.com:10631/'`
in `settings/private.py' and running celery worker with this command inside journals container
`DJANGO_SETTINGS_MODULE='journals.settings.local' celery -A journals worker -l info`