### PR TITLE
Move allow credentials headers to dev only

### DIFF
--- a/journals/settings/base.py
+++ b/journals/settings/base.py
@@ -333,7 +333,6 @@ WAGTAIL_FRONTEND_LOGIN_URL = LOGIN_URL
 
 THEME_DIR = '/edx/app/journals/themes/'
 
-CORS_ALLOW_CREDENTIALS = True
 CSRF_COOKIE_NAME = 'journals_csrftoken'
 
 ALLOWED_DOCUMENT_TYPES = ['application/pdf']

--- a/journals/settings/local.py
+++ b/journals/settings/local.py
@@ -61,6 +61,8 @@ CORS_ORIGIN_WHITELIST = (
     'localhost:1991'
 )
 
+CORS_ALLOW_CREDENTIALS = True
+
 #####################################################################
 # Lastly, see if the developer has any local overrides.
 if os.path.isfile(join(dirname(abspath(__file__)), 'private.py')):


### PR DESCRIPTION
Current setup is breaking when headers are added by webserver config.