### PR TITLE
ARCH-233: Add JWT Auth Middleware.

### DIFF
--- a/journals/settings/base.py
+++ b/journals/settings/base.py
@@ -92,6 +92,8 @@ MIDDLEWARE_CLASSES = (
     'wagtail.wagtailredirects.middleware.RedirectMiddleware',
     'edx_django_utils.cache.middleware.TieredCacheMiddleware',
     'edx_rest_framework_extensions.middleware.RequestMetricsMiddleware',
+    'edx_rest_framework_extensions.auth.jwt.middleware.EnsureJWTAuthSettingsMiddleware',
+    'edx_rest_framework_extensions.auth.jwt.middleware.JwtAuthCookieMiddleware',
 )
 
 ROOT_URLCONF = 'journals.urls'

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -12,7 +12,7 @@ djangorestframework-jwt==1.8.0
 edx-auth-backends==1.1.3
 edx-django-release-util==0.3.1
 edx-django-utils==1.0.1
-edx-drf-extensions==1.6.1
+edx-drf-extensions==1.10.0
 edx_rest_api_client==1.8.2
 elasticsearch>=5.0.0,<6.0.0
 jsonfield==2.0.2


### PR DESCRIPTION
From edx-drf-extensions:
1. EnsureJWTAuthSettingsMiddleware: Ensures proper JWT auth settings
   for endpoints.
2. JwtAuthCookieMiddleware: Combines the JWT auth cookie parts into a
   JWT auth cookie.

ARCH-233