### PR TITLE
WL-1780: Moved creation of video index, document index and execution of management commands into background tasks

### DIFF
--- a/journals/apps/journals/wagtailadmin/tasks.py
+++ b/journals/apps/journals/wagtailadmin/tasks.py
@@ -1,0 +1,23 @@
+"""
+Module to define background tasks for wagtail admin related features
+"""
+import logging
+
+from background_task import background
+from django.core import management
+from django.core.management import CommandError
+
+log = logging.getLogger(__name__)
+
+
+@background(schedule=30)
+def task_run_management_command(command):
+    """
+    Task to run management command
+    """
+
+    try:
+        management.call_command(command)
+        log.info("Command %s successully executed.", command)
+    except CommandError as ex:
+        log.exception("Failed to executed %s command, Error: %s ", command, str(ex))

--- a/journals/apps/journals/wagtailadmin/views.py
+++ b/journals/apps/journals/wagtailadmin/views.py
@@ -26,6 +26,7 @@ from wagtail.wagtailcore.models import Collection
 
 from journals.apps.journals.api_utils import get_discovery_journal
 from journals.apps.journals.wagtailadmin.forms import JournalEditForm, JournalCreateForm
+from journals.apps.journals.wagtailadmin.tasks import task_run_management_command
 from journals.apps.journals.models import Journal, Organization
 from journals.apps.journals.permissions import video_permission_policy
 from journals.apps.journals.utils import add_messages
@@ -428,10 +429,8 @@ class AdminCommandsView(TemplateView):
             stderr.write('Unknown command "%s"' % management_command)
         else:
             try:
-                management.call_command(
-                    management_command,
-                    stdout=stdout, stderr=stderr
-                )
+                task_run_management_command(management_command)
+                stdout.write("Command %s successully queued to run in the background process." % management_command)
             except Exception as ex:  # pylint: disable=broad-except
                 stderr.write(str(ex))
 

--- a/journals/apps/search/tasks.py
+++ b/journals/apps/search/tasks.py
@@ -1,0 +1,57 @@
+"""
+Module to define background tasks for search related features
+"""
+import logging
+
+from background_task import background
+from wagtail.wagtailsearch.backends import get_search_backends
+
+log = logging.getLogger(__name__)
+
+
+@background(schedule=30)
+def task_index_journal_document(document_id):
+    """
+    Task to create elastic search index for journal documents
+    """
+    from journals.apps.journals.models import JournalDocument
+    from journals.apps.search.backend import INGEST_ATTACHMENT_ID
+
+    try:
+        item = JournalDocument.objects.get(pk=document_id)
+    except JournalDocument.DoesNotExist:
+        log.error('JournalDocument with id %s does not exist', document_id)
+        return
+
+    for backend in get_search_backends():
+        search_index = backend.get_index_for_model(type(item))
+    mapping = search_index.mapping_class(item.__class__)
+    results = search_index.es.index(
+        search_index.name,
+        mapping.get_document_type(),
+        mapping.get_document(item),
+        pipeline=INGEST_ATTACHMENT_ID,
+        id=mapping.get_document_id(item)
+    )
+    log.info('indexed document with attachment results=%s', results)
+
+
+@background(schedule=30)
+def task_index_journal_video(video_id):
+    """
+    Task to create elastic search index for videos
+    """
+    from journals.apps.journals.models import Video
+
+    try:
+        item = Video.objects.get(pk=video_id)
+    except Video.DoesNotExist:
+        log.error('Video with id %s does not exist', video_id)
+        return
+
+    for backend in get_search_backends():
+        search_index = backend.get_index_for_model(type(item))
+
+    # call add_item method of base class to avoid recursive loop
+    super(search_index.__class__, search_index).add_item(item)
+    log.info('indexed video with id=%s', video_id)

--- a/journals/settings/base.py
+++ b/journals/settings/base.py
@@ -35,6 +35,7 @@ INSTALLED_APPS = (
     'modelcluster',
     'release_util',
     'taggit',
+    'background_task',
 )
 
 THIRD_PARTY_APPS = (
@@ -341,3 +342,8 @@ ALLOWED_DOCUMENT_TYPES = ['application/pdf']
 ALLOWED_DOCUMENT_FILE_EXTENSIONS = ['.pdf']
 
 BATCH_SIZE_FOR_LMS_USER_API = 50
+
+# background_task
+# how many times a task will be attempted
+MAX_ATTEMPTS = 2
+# End background_task

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -20,3 +20,4 @@ mysqlclient==1.3.12
 pytz==2018.3
 wagtail>=1.13,<1.14
 django-cors-headers==2.3.0
+django-background-tasks==1.2.0


### PR DESCRIPTION
This PR has changes to move creation of video index, document index and execution of management commands into background tasks.

Testing instructions
1) Run journals in one terminal
2) Run background tasks management command in another terminal
```
./manage.py process_tasks
```
2) Import videos, add a new document, run a management command i.e `update_index` from journals editor and monitor terminal to see how background tasks are executed.

@bill-filler could you please review? 
