### PR TITLE
limit size of attachment uploaded to elasticsearch

### DIFF
--- a/journals/settings/base.py
+++ b/journals/settings/base.py
@@ -343,3 +343,4 @@ ALLOWED_DOCUMENT_TYPES = ['application/pdf']
 ALLOWED_DOCUMENT_FILE_EXTENSIONS = ['.pdf']
 
 BATCH_SIZE_FOR_LMS_USER_API = 50
+MAX_ELASTICSEARCH_UPLOAD_SIZE = 10000000  # maximum number of bytes per document that can be uploaded to elasticsearch


### PR DESCRIPTION
We limit our file upload size via wagtail, but Elasticsearch has a 10MB limit of content uploaded to it. So we need to make sure documents (which are base64 encoded and larger than original file) and video transcripts are limited to that size. 

Rather than rejecting, we'll upload the first 10MB of document contents or video transcript and ignore the rest. 