### PR TITLE
don't allow creating a JournalAboutPage directly from page menu

### DIFF
--- a/journals/apps/journals/models.py
+++ b/journals/apps/journals/models.py
@@ -663,7 +663,7 @@ class JournalIndexPage(JournalPageMixin, Page):
     The marketing page that shows all the journals available on a given site.
     Publicly available.
     """
-    subpage_types = ['JournalAboutPage']
+    subpage_types = []
 
     hero_image = models.ForeignKey(
         JournalImage, on_delete=models.SET_NULL, related_name='+', null=True, blank=True


### PR DESCRIPTION
We shouldn't be directly creating JournalAboutPages from the Pages UI in wagtail as it can cause problems if the underlying Journal hasn't yet been created. Instead, JournalAboutPages get created automatically when you create a Journal via the Journal section of wagtail. 