### PR TITLE
increase read/write timeout for elasticsearch

### DIFF
--- a/journals/apps/journals/models.py
+++ b/journals/apps/journals/models.py
@@ -313,7 +313,9 @@ class JournalDocument(AbstractDocument):
         # converting to base64 is (Size * 8)/6 times bigger than binary file
         # determine the max number of bytes we can read to not exceed the max upload size
         read_max = (settings.MAX_ELASTICSEARCH_UPLOAD_SIZE * 6) / 8
+        self.file.open()
         contents = base64.b64encode(self.file.read(int(read_max))).decode('ascii')
+        self.file.close()
         return contents
 
     def get_viewer_url(self, base_url):

--- a/journals/settings/base.py
+++ b/journals/settings/base.py
@@ -324,8 +324,8 @@ WAGTAILSEARCH_BACKENDS = {
         'BACKEND': 'journals.apps.search.backend',
         'URLS': ['http://journals.elasticsearch:9200'],
         'INDEX': 'journals',
-        'TIMEOUT': 5,
-        'OPTIONS': {},
+        'TIMEOUT': 20,
+        'OPTIONS': {'max_retries': 2, 'retry_on_timeout': True},
         'INDEX_SETTINGS': {},
     }
 }


### PR DESCRIPTION
Seeing lots of read timeouts in splunk when trying to upload largeish documents. This bumps the default timeout up to try and avoid. 