### PR TITLE
add Videos to django-admin

### DIFF
--- a/journals/apps/journals/admin/django_admin.py
+++ b/journals/apps/journals/admin/django_admin.py
@@ -7,6 +7,7 @@ from journals.apps.journals.models import (
     JournalAboutPage,
     JournalAccess,
     Organization,
+    Video,
 )
 from journals.apps.journals.views import JournalAccessView
 
@@ -44,3 +45,4 @@ class JournalAccessAdmin(admin.ModelAdmin):
 
 # Default admin pages below
 admin.site.register(Organization)
+admin.site.register(Video)


### PR DESCRIPTION
Add Videos to django-admin in case we need to delete any, which is currently not supported in the wagtail UI.