### PR TITLE
ARCH-262: Reverts addition of JwtAuthCookieMiddleware

### DIFF
--- a/journals/settings/base.py
+++ b/journals/settings/base.py
@@ -93,7 +93,6 @@ MIDDLEWARE_CLASSES = (
     'edx_django_utils.cache.middleware.TieredCacheMiddleware',
     'edx_rest_framework_extensions.middleware.RequestMetricsMiddleware',
     'edx_rest_framework_extensions.auth.jwt.middleware.EnsureJWTAuthSettingsMiddleware',
-    'edx_rest_framework_extensions.auth.jwt.middleware.JwtAuthCookieMiddleware',
 )
 
 ROOT_URLCONF = 'journals.urls'


### PR DESCRIPTION
When JWT cookies are required, there will be some work needed to make this work.  
See "[ARCH-266: Backend: Enable JWT Cookies in remaining IDAs.](https://openedx.atlassian.net/browse/ARCH-266)"