### PR TITLE
update 403 page to remove old header

### DIFF
--- a/journals/apps/journals/templates/403.html
+++ b/journals/apps/journals/templates/403.html
@@ -1,14 +1,7 @@
-{% extends "base.html" %}
-
-{% load wagtailcore_tags %}
-
-{% block content %}
-    <div id="journal-403-page" class="container">
-        <div class="row">
-            <div class="col-12 content">
-                <h3>Access Denied</h3>
-                <p>You have not purchased access to this content.</p>
-            </div>
-        </div>
+<html>
+    <body>
+    <div>
+        <h3>Access Denied</h3>
     </div>
-{% endblock %}
+    </body>
+</html>


### PR DESCRIPTION
update existing 403 page to remove the old header as we don't want it anymore. This only gets shown if someone tries to access something in wagtail that they don't have permissions for