### PR TITLE
WL-1848: disable notification preferences by default

### DIFF
--- a/journals/apps/core/__init__.py
+++ b/journals/apps/core/__init__.py
@@ -1,0 +1,5 @@
+"""
+Core App
+"""
+
+default_app_config = 'journals.apps.core.apps.CoreAppConfig'

--- a/journals/apps/core/apps.py
+++ b/journals/apps/core/apps.py
@@ -1,0 +1,16 @@
+"""
+App Configuration for core
+"""
+from __future__ import absolute_import, division, print_function, unicode_literals
+from django.apps import AppConfig
+
+
+class CoreAppConfig(AppConfig):
+    """
+    App Configuration for core
+    """
+    name = 'journals.apps.core'
+    verbose_name = 'Core'
+
+    def ready(self):
+        from . import handlers  # pylint: disable=unused-variable

--- a/journals/apps/core/handlers.py
+++ b/journals/apps/core/handlers.py
@@ -1,0 +1,20 @@
+"""
+Signal handlers for core app
+"""
+from django.db.models.signals import post_save
+from django.dispatch import receiver
+
+from wagtail.wagtailusers.models import UserProfile
+
+from journals.apps.core.models import User
+
+
+@receiver(post_save, sender=User)
+def create_user_profile(sender, instance, created, **kwargs):  # pylint: disable=unused-argument
+    if created:
+        UserProfile.objects.create(
+            user=instance,
+            submitted_notifications=False,
+            approved_notifications=False,
+            rejected_notifications=False
+        )

--- a/journals/apps/core/tests/test_handlers.py
+++ b/journals/apps/core/tests/test_handlers.py
@@ -1,0 +1,37 @@
+"""
+Tests for signal handlers
+"""
+from django.test import TestCase
+
+from journals.apps.core.tests.factories import (
+    UserFactory,
+)
+
+
+class TestUserPostSave(TestCase):
+    """
+    Test Cases for post_save signal of User model.
+    """
+
+    def test_notification_settings_disabled_on_user_creation(self):
+        """
+        Test user's notifications preferences are disabled at the time of user creation
+        """
+        user = UserFactory()
+        self.assertFalse(user.wagtail_userprofile.submitted_notifications)
+        self.assertFalse(user.wagtail_userprofile.approved_notifications)
+        self.assertFalse(user.wagtail_userprofile.rejected_notifications)
+
+    def test_notification_settings_can_be_enbled(self):
+        """
+        Test user's notifications preferences can be enabled by updating user's profile
+        """
+        user = UserFactory()
+        userprofile = user.wagtail_userprofile
+        userprofile.submitted_notifications = True
+        userprofile.approved_notifications = True
+        userprofile.rejected_notifications = True
+        userprofile.save()
+        self.assertTrue(user.wagtail_userprofile.submitted_notifications)
+        self.assertTrue(user.wagtail_userprofile.approved_notifications)
+        self.assertTrue(user.wagtail_userprofile.rejected_notifications)


### PR DESCRIPTION
This PR has changes to disable user's notification preferences by default.

To test it.
1. Signup on journals.
2. As an admin user changes role of newly created user to have editors or moderator privileges
3. Log in with newly created user and make sure check boxes under [notifications preferences are](http://localhost:18606/cms/account/notification_preferences/) unchecked.

@bill-filler could you please review?