### PR TITLE
"Open File" option Removed from pdf.js

### DIFF
--- a/journals/apps/journals/static/pdf_js/web/viewer.html
+++ b/journals/apps/journals/static/pdf_js/web/viewer.html
@@ -357,7 +357,7 @@ See https://github.com/adobe-type-tools/cmap-resources
 
     <!-- NON PDF.JS CUSTOM CODE -->
     <style>
-      #print, #download{
+      #print, #download, #openFile, #secondaryOpenFile{
         display: none !important;
       }
     </style>


### PR DESCRIPTION
"Open File" option Removed from pdf.js
========================================

There was "Open File" menu option in the pdf viewer.
Changed the pdf.js code in journals to never display the Open File button.