### PR TITLE
WL-1844: set BASE_URL setting by geting scheme and host from request

### DIFF
--- a/journals/apps/core/middleware.py
+++ b/journals/apps/core/middleware.py
@@ -1,8 +1,11 @@
 """
 Journals core middleware module
 """
+from urllib.parse import urlunsplit
+
 from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist
+
 from wagtail.wagtailcore.models import Site
 
 
@@ -11,6 +14,9 @@ class SettingsOverrideMiddleware(object):
         """
         Overrides django settings based on request
         """
+        base_url = urlunsplit((request.scheme, request.get_host(), '', '', ''))
+        setattr(settings, 'BASE_URL', base_url)
+
         try:
             site = Site.find_for_request(request)
             setattr(settings, 'WAGTAILADMIN_NOTIFICATION_FROM_EMAIL', site.siteconfiguration.from_email)

--- a/journals/apps/core/tests/test_middleware.py
+++ b/journals/apps/core/tests/test_middleware.py
@@ -1,6 +1,6 @@
 """ Test Cases for middleware """
 import ddt
-from mock import patch
+from mock import PropertyMock, patch
 
 from django.conf import settings
 from django.test import TestCase
@@ -26,7 +26,7 @@ class TestSettingsMiddleware(TestCase):
     @ddt.unpack
     def test_notification_settings_override(self, hostname, from_email):
         """
-        Test WAGTAILADMIN_NOTIFICATION_FROM_EMAIL setting override base on site
+        Test WAGTAILADMIN_NOTIFICATION_FROM_EMAIL setting override based on site
         """
         site = SiteFactory(hostname=hostname)
         site_configuration = SiteConfigurationFactory(site=site, from_email=from_email)
@@ -36,3 +36,22 @@ class TestSettingsMiddleware(TestCase):
             response = self.client.get(url)
             self.assertEqual(response.status_code, 200)
             self.assertEqual(settings.WAGTAILADMIN_NOTIFICATION_FROM_EMAIL, site_configuration.from_email)
+
+    @ddt.data(
+        ('http', 'example.com'),
+        ('https', 'dummy.org'),
+        ('ftp', 'test.co.name'),
+    )
+    @ddt.unpack
+    @patch('django.core.handlers.wsgi.WSGIRequest.get_host')
+    @patch('django.core.handlers.wsgi.WSGIRequest.scheme', new_callable=PropertyMock)
+    def test_base_url_setting_override(self, scheme, hostname, mock_scheme, mock_host):
+        """
+        Test BASE_URL setting override
+        """
+        url = "{}://{}".format(scheme, hostname)
+        mock_scheme.return_value = scheme
+        mock_host.return_value = hostname
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(settings.BASE_URL, url)


### PR DESCRIPTION
This PR sets `BASE_URL` setting by geting scheme and host from request to fix issue reported in WL-1844.

@bill-filler could you please review?