### PR TITLE
Hammad/WL 1845 Disable dangerous creation/deletion options in Journal Editor

### DIFF
--- a/journals/apps/core/management/commands/create_site.py
+++ b/journals/apps/core/management/commands/create_site.py
@@ -2,6 +2,7 @@
 from urllib.parse import urljoin
 
 from django.contrib.auth.models import Group, Permission
+from django.core.management import call_command
 from django.core.management.base import BaseCommand
 from django.db import transaction
 
@@ -109,6 +110,10 @@ class Command(BaseCommand):
         parser.add_argument(
             '--frontend-url',
             help='Frontend app URL for Journals app',
+        )
+        parser.add_argument(
+            '--org',
+            help='Organization associated with the Site',
         )
 
     def create_index_page(self, sitename):
@@ -299,3 +304,12 @@ class Command(BaseCommand):
             index_page=index_page,
             collection=collection,
         )
+
+        # If organization specified, associate the site with it
+        org = options.get('org', None)
+        if org:
+            call_command(
+                'create_org',
+                '--key', org,
+                '--sitename', sitename
+            )

--- a/journals/apps/journals/admin/django_admin.py
+++ b/journals/apps/journals/admin/django_admin.py
@@ -6,6 +6,7 @@ from journals.apps.journals.models import (
     Journal,
     JournalAboutPage,
     JournalAccess,
+    JournalIndexPage,
     Organization,
     Video,
 )
@@ -16,6 +17,18 @@ from journals.apps.journals.views import JournalAccessView
 @admin.register(JournalAboutPage)
 class JournalAboutPageAdmin(admin.ModelAdmin):
     fields = ('journal',)
+
+    def has_add_permission(self, request):
+        return False
+
+
+@admin.register(JournalIndexPage)
+class JournalIndexPageAdmin(admin.ModelAdmin):
+    fields = ('title',)
+    readonly_fields = ('title',)
+
+    def has_add_permission(self, request):
+        return False
 
 
 @admin.register(Journal)

--- a/journals/apps/journals/models.py
+++ b/journals/apps/journals/models.py
@@ -484,7 +484,9 @@ class JournalAboutPage(JournalPageMixin, Page):
         FieldPanel('custom_content'),
     ]
 
-    parent_page_types = ['JournalIndexPage']
+    #  Setting parent_page_types to an empty list to prevent from being created in the editor interface.
+    #  Reference: http://docs.wagtail.io/en/v2.0/topics/pages.html#parent-page-subpage-type-rules
+    parent_page_types = []
     subpage_types = ['JournalPage']
 
     api_fields = [
@@ -703,6 +705,9 @@ class JournalIndexPage(JournalPageMixin, Page):
         APIField('intro'),
         APIField('hero_image_url')
     ]
+
+    #  Setting parent_page_types to an empty list to prevent from being created in the editor interface.
+    parent_page_types = []
 
     @property
     def hero_image_url(self):


### PR DESCRIPTION
Disable dangerous creation/deletion options in Journal Editor
=====================================================================

As we create and delete Journals from "Journals" panel (which in turn
creates appopriate Index and About Pages), So restricted editors to
directly to create or delete these types of pages through the Wagtail UI.