### PR TITLE
Dynamically import SiteConfig in utils

### DIFF
--- a/journals/settings/utils.py
+++ b/journals/settings/utils.py
@@ -2,9 +2,8 @@ import logging
 from os import environ
 from urllib.parse import urlsplit
 
+from django.apps import apps
 from django.core.exceptions import ImproperlyConfigured
-
-from journals.apps.core.models import SiteConfiguration
 
 logger = logging.getLogger(__name__)
 
@@ -24,6 +23,7 @@ def get_whitelist_domains(request):
     """
     (_, request_domain, _, _, _) = urlsplit(request.build_absolute_uri())
     permitted_domains = [request_domain]
+    SiteConfiguration = apps.get_model('core', 'SiteConfiguration')
     try:
         for key, value in request.site.siteconfiguration.__dict__.items():
             if "url" in key.lower() and type(value) == str:


### PR DESCRIPTION
get_env_setting is used in settings when apps aren't loaded yet.

Build pipeline has been failing since this import was added. Not reproducible locally, so we'll need to verify this fixes it once merged. 