### PR TITLE
WL-1851| test_search_across_multiple_journals_with_AND_operator is flaky

### DIFF
--- a/journals/apps/api/v1/search/views.py
+++ b/journals/apps/api/v1/search/views.py
@@ -7,6 +7,8 @@
         <query_string>: The text to search, should be url encoded
         <operator>: 'or' - to match any terms in the query_string (default)
                     'and' - exact match for all the terms in the query_string
+                            (Note: AND is overridden to 'phrase' type search.
+                             https://www.elastic.co/guide/en/elasticsearch/guide/current/phrase-matching.html#_what_is_a_phrase)
         <type>: 'all' - search across all content types (default)
                 'images' - search for images only
                 'documents' - search in documents only


### PR DESCRIPTION
test_search_across_multiple_journals_with_AND_operator is flaky
====================================================================

The test_search_across_multiple_journals_with_AND_operator test in the
journals IDA is flaky. It was failing on multiple PRs and a rerun fixed
it.

`and` was overridden to work as `phrase` type search but test was testing it As `and`
Logic. Now test modified according to "phrase" type search.

also all `contains` are converted to `icontains` to support case insensitive testing.  