### PR TITLE
WL-1853: added code block support to rich text editor

### DIFF
--- a/journals/apps/journals/models.py
+++ b/journals/apps/journals/models.py
@@ -51,7 +51,9 @@ logger = logging.getLogger(__name__)
 JOURNAL_PAGE_PREVIEW_PATH = 'pagePreview'
 JOURNAL_ABOUT_PAGE_PREVIEW_PATH = 'aboutPreview'
 JOURNAL_INDEX_PAGE_PREVIEW_PATH = 'indexPreview'
-RICH_TEXT_FEATURES = ['h1', 'h2', 'h3', 'ol', 'ul', 'bold', 'italic', 'link', 'hr', 'document-link', 'image']
+RICH_TEXT_FEATURES = [
+    'h1', 'h2', 'h3', 'ol', 'ul', 'bold', 'italic', 'link', 'hr', 'document-link', 'image', 'code-block'
+]
 
 # TODO: Make working 'document-link' and 'image' for RichTextField (currently not click-able on frontend.)
 RICH_TEXT_FIELD_FEATURES = ['h1', 'h2', 'h3', 'ol', 'ul', 'hr', 'bold', 'italic', 'link']

--- a/journals/apps/journals/static/js/lib/halo_codeblock_plugin.js
+++ b/journals/apps/journals/static/js/lib/halo_codeblock_plugin.js
@@ -1,0 +1,83 @@
+(function() {
+	(function ($) {
+		return $.widget('IKS.hallowagtailcodeblock', {
+			options: {
+				uuid: '',
+				editable: null
+			},
+			populateToolbar: function (toolbar) {
+				var codeButton, widget, getEnclosingCode, codeBlock, removerAllChildren;
+
+				widget = this;
+				codeButton = $('<span class="' + this.widgetName + '"></span>');
+				getEnclosingCode = function () {
+					var node = widget.options.editable.getSelection().commonAncestorContainer;
+					return $(node).parents('code').get(0);
+				};
+				removerAllChildren = function (node) {
+					while (node.firstChild) {
+						node.removeChild(node.firstChild);
+					}
+				};
+				codeButton.hallobutton({
+					uuid: this.options.uuid,
+					editable: this.options.editable,
+					label: 'CodeBlock',
+					icon: 'icon-code',
+					command: null,
+					queryState: function (event) {
+						return codeButton.hallobutton('checked', !!getEnclosingCode());
+					}
+				});
+				toolbar.append(codeButton);
+				return codeButton.on('click', function (event) {
+					var urlParams = {};
+					var lastSelection = widget.options.editable.getSelection();
+					var enclosingCode = getEnclosingCode();
+					if (enclosingCode) {
+						urlParams['code_block'] = $(enclosingCode).text();
+					} else if (!lastSelection.collapsed) {
+						urlParams['code_block'] = lastSelection.toString();
+					}
+
+					return ModalWorkflow({
+						url: window.chooserUrls.insertCodeBlock,
+						urlParams: urlParams,
+						responses: {
+							insertedCodeBlock: function (data) {
+								var pre, code;
+								var codeBlock = document.createTextNode(data.code);
+								if (enclosingCode) {
+									// Editing an existing code block
+									code = enclosingCode;
+									removerAllChildren(code);
+									pre = $(code).parents('pre').get(0);
+								} else if (!lastSelection.collapsed) {
+									// Turning a selection into a code block
+									pre = document.createElement('pre');
+									code = document.createElement('code');
+									pre.appendChild(code);
+									var nodesInSelection = lastSelection.getNodes();
+									if (nodesInSelection.length > 0) {
+										var parentNode = nodesInSelection[0].parentNode;
+										removerAllChildren(parentNode);
+										parentNode.appendChild(pre);
+									}
+								} else {
+									pre = document.createElement('pre');
+									code = document.createElement('code');
+									pre.appendChild(code);
+									lastSelection.insertNode(pre);
+								}
+								code.appendChild(codeBlock);
+								hljs.highlightBlock(pre);
+								return widget.options.editable.element.trigger('change');
+							}
+						}
+					});
+				});
+			}
+		});
+	})(jQuery);
+
+}).call(this);

--- a/journals/apps/journals/templates/wagtailadmin/halo/code_block.html
+++ b/journals/apps/journals/templates/wagtailadmin/halo/code_block.html
@@ -1,0 +1,19 @@
+{% load i18n %}
+{% if code_block == '' %}
+    {% trans "Add code block" as add_str %}
+{% else %}
+    {% trans "Edit code block" as add_str %}
+{% endif %}
+{% include "wagtailadmin/shared/header.html" with title=add_str %}
+
+<ul class="fields" style="list-style: none; padding-right: 40px">
+    <li>
+        <label for="id_insert_code_block">{% trans "Enter Code:" %}</label>
+        <div>
+            <textarea id="id_insert_code_block" name="code_block" rows="10">{{ code_block }}</textarea>
+        </div>
+    </li>
+    <li>
+        <span class="working icon"></span><button type="button" class="button insert-code">{{add_str}}</button>
+    </li>
+</ul>

--- a/journals/apps/journals/templates/wagtailadmin/halo/code_inserted.js
+++ b/journals/apps/journals/templates/wagtailadmin/halo/code_inserted.js
@@ -1,0 +1,6 @@
+function(modal) {
+	$('button.insert-code').on('click', function (event) {
+		modal.respond('insertedCodeBlock', {'code': $('#id_insert_code_block').val()});
+		modal.close();
+	});
+}

--- a/journals/apps/journals/urls.py
+++ b/journals/apps/journals/urls.py
@@ -10,4 +10,5 @@ urlpatterns = [
     url(r'^import_videos/$', wagtailadmin_views.VideoImportView.as_view(), name='import_videos'),
     url(r'^video_chooser/$', video_chooser_views.chooser, name='video_chooser'),
     url(r'^video_chooser/(\d+)/$', video_chooser_views.video_chosen, name='video_chosen'),
+    url(r'^insert_code_block/$', wagtailadmin_views.AdminInsertCodeBlockView.as_view(), name='insert_code_block'),
 ]

--- a/journals/apps/journals/wagtailadmin/views.py
+++ b/journals/apps/journals/wagtailadmin/views.py
@@ -20,6 +20,7 @@ from wagtail.utils.pagination import paginate
 from wagtail.wagtailadmin import messages
 from wagtail.wagtailadmin.edit_handlers import FieldPanel, MultiFieldPanel, ObjectList
 from wagtail.wagtailadmin.forms import SearchForm
+from wagtail.wagtailadmin.modal_workflow import render_modal_workflow
 from wagtail.wagtailadmin.navigation import get_explorable_root_page
 from wagtail.wagtailadmin.views.pages import move_choose_destination
 from wagtail.wagtailcore.models import Collection
@@ -439,6 +440,23 @@ class AdminCommandsView(TemplateView):
             'success_message': linebreaks(stdout.getvalue()),
             'failure_message': linebreaks(stderr.getvalue()),
         })
+
+
+class AdminInsertCodeBlockView(TemplateView):
+    """
+    View to render code block text input while inserting code block in WYSIWYG editor
+    """
+    template_name = 'wagtailadmin/halo/code_block.html'
+
+    def get(self, request, *args, **kwargs):
+        return render_modal_workflow(
+            request,
+            self.template_name,
+            'wagtailadmin/halo/code_inserted.js',
+            {
+                'code_block': request.GET.get('code_block', '')
+            }
+        )
 
 
 def move_page(request, page_to_move_id):


### PR DESCRIPTION
This PR has changes to add code block insertion support in wagtail admin's rich text editor.

To test 

1. add new code block
move pointer in text editor to a point where you want to add code block and click `CodeBlock` button. Enter code in the input box of popup window and hit `Add code block` button

2. Edit existing code block
Move pointer to anywhere in the existing code block it should highlight `CodeBlock` button. Click the `CodeBlock` button and edit your code block

3. Convert any text in the rich text editor
Select the text you want to convert into a code block and hit `CodeBlock` button.